### PR TITLE
Add extraFixedCaseWords option to prefer-title-case rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ node_modules
 # build folder
 dist
 # misc
+.vscode
 .DS_Store
 *.tgz

--- a/lib/title-case.ts
+++ b/lib/title-case.ts
@@ -15,7 +15,7 @@
 // - The second word in a hyphenated compound (except for `Built-in` and `Plug-in`)
 //   - High-Level Events
 //   - 32-Bit Addressing
-export function titleCase(s: string): string {
+export function titleCase(s: string, extraFixedCaseWords?: string[]): string {
   // Define the words that should not be capitalized unless they are the first or last word in the title or follow a colon.
   const noCaps: { [key: string]: boolean } = {
     and: true,
@@ -73,7 +73,7 @@ export function titleCase(s: string): string {
     "plug-in": "Plug-in",
     "pub.dev": "pub.dev",
     "ray.so": "ray.so",
-    "servicenow": "ServiceNow",
+    servicenow: "ServiceNow",
     svg: "SVG",
     totp: "TOTP",
     url: "URL",
@@ -81,6 +81,13 @@ export function titleCase(s: string): string {
     vs: "VS",
     vscode: "VS Code",
     xkcd: "xkcd",
+  };
+
+  // Merge user-provided extra fixed case words and built-in words
+  // Built-in words have higher priority
+  const allFixedCaseWords = {
+    ...Object.fromEntries((extraFixedCaseWords || []).map((word) => [word.toLowerCase(), word])),
+    ...fixedCaseWords,
   };
 
   // Replace all instances of '...' with '…'
@@ -107,17 +114,13 @@ export function titleCase(s: string): string {
     const lowerWord = word.toLowerCase();
     const ok = noCaps[lowerWord];
     const isArticle = articles[lowerWord];
-    const fixedCase = fixedCaseWords[lowerWord];
+    const fixedCase = allFixedCaseWords[lowerWord];
 
     if (fixedCase) {
       words[i] = fixedCase;
     } else if (word.startsWith("http://") || word.startsWith("https://")) {
       words[i] = word;
-    } else if (
-      (!ok && !isArticle) ||
-      i === 0 ||
-      (isArticle && words[i - 1].endsWith(":"))
-    ) {
+    } else if ((!ok && !isArticle) || i === 0 || (isArticle && words[i - 1].endsWith(":"))) {
       words[i] = word
         .split("-")
         .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@raycast/eslint-plugin",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@raycast/eslint-plugin",
-      "version": "2.0.6",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^8.26.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raycast/eslint-plugin",
-  "version": "2.0.7",
+  "version": "2.1.0",
   "description": "ESLint plugin designed to help Raycast's extensions authors follow best practices",
   "author": "Raycast Technologies Ltd.",
   "keywords": [

--- a/tests/prefer-title-case.test.ts
+++ b/tests/prefer-title-case.test.ts
@@ -62,6 +62,37 @@ ruleTester.run("prefer-title-case", rule, {
         <Action.OpenInBrowser url="https://www.cs.utah.edu/~mflatt/" title="https://www.cs.utah.edu/~mflatt/" />
       `,
     },
+    {
+      code: `
+        <Action title="MyApp DevTool" />
+      `,
+      options: [{ extraFixedCaseWords: ["MyApp", "DevTool"] }],
+    },
+    {
+      code: `
+        <Action title={"MyApp DevTool"} />
+      `,
+      options: [{ extraFixedCaseWords: ["MyApp", "DevTool"] }],
+    },
+    {
+      code: `
+        <Action title={isEnabled ? "MyApp DevTool" : "MyApp Tool"} />
+      `,
+      options: [{ extraFixedCaseWords: ["MyApp", "DevTool"] }],
+    },
+    {
+      code: `
+        <Action title={\`MyApp DevTool\`} />
+      `,
+      options: [{ extraFixedCaseWords: ["MyApp", "DevTool"] }],
+    },
+    // Built-in words have higher priority than user-provided words
+    {
+      code: `
+        <Action title="GitHub DevTool" />
+      `,
+      options: [{ extraFixedCaseWords: ["github", "DevTool"] }],
+    },
   ],
   invalid: [
     {
@@ -176,10 +207,7 @@ ruleTester.run("prefer-title-case", rule, {
       code: `
         <Action title={isAssignedToMe ? "Assign to me" : "Unassign from me"} />
       `,
-      errors: [
-        { messageId: "isNotTitleCased" },
-        { messageId: "isNotTitleCased" },
-      ],
+      errors: [{ messageId: "isNotTitleCased" }, { messageId: "isNotTitleCased" }],
       output: `
         <Action title={isAssignedToMe ? "Assign to Me" : "Unassign from Me"} />
       `,
@@ -194,6 +222,43 @@ ruleTester.run("prefer-title-case", rule, {
     },
     {
       code: "<Action title={`Submit form to ${service} and also to ${service2}`} />",
+      errors: [{ messageId: "isNotTitleCased" }],
+    },
+    {
+      code: `
+        <Action title="MyApp DevTool" />
+      `,
+      options: [{ extraFixedCaseWords: ["MyApp"] }],
+      errors: [{ messageId: "isNotTitleCased" }],
+      output: `
+        <Action title="MyApp Devtool" />
+      `,
+    },
+    {
+      code: `
+        <Action title={"myapp devtool"} />
+      `,
+      options: [{ extraFixedCaseWords: ["MyApp", "DevTool"] }],
+      errors: [{ messageId: "isNotTitleCased" }],
+      output: `
+        <Action title={"MyApp DevTool"} />
+      `,
+    },
+    {
+      code: `
+        <Action title={isEnabled ? "myapp devtool" : "myapp tool"} />
+      `,
+      options: [{ extraFixedCaseWords: ["MyApp", "DevTool"] }],
+      errors: [{ messageId: "isNotTitleCased" }, { messageId: "isNotTitleCased" }],
+      output: `
+        <Action title={isEnabled ? "MyApp DevTool" : "MyApp Tool"} />
+      `,
+    },
+    {
+      code: `
+        <Action title={\`myapp devtool\`} />
+      `,
+      options: [{ extraFixedCaseWords: ["MyApp", "DevTool"] }],
       errors: [{ messageId: "isNotTitleCased" }],
     },
   ],


### PR DESCRIPTION
## 🎯 Motivation

When developing Raycast extensions, extension titles often contain proprietary names (brands, app names) that have specific capitalization requirements. For example, the social app "[WeChat](https://www.wechat.com/en/)" should be written as `WeChat` (not `Wechat`), similar to how `iOS` has specific capitalization.

Currently, the prefer-title-case rule enforces standard title case formatting, which can conflict with these proprietary naming conventions (except for built-in words like `iOS`, `GitHub`, `macOS`, etc. as defined in [here](https://github.com/raycast/eslint-plugin/blob/fdc466733f48187e943f644bd98447eff73a4fe1/lib/title-case.ts#L51)).

**Example**
```json
{
  "$schema": "https://www.raycast.com/schemas/extension.json",
  "name": "wechat-devtool",
  "title": "WeChat DevTool"
}
```

This triggers a warning:
```shell
$ npm run lint

> wechat-devtool@1.3.0 lint
> ray lint

wait  - validate package.json file ... /Users/frankie/Web/Git/raycast/extensions/extensions/wechat-devtool/package.json
  4:11  warning  Extension's title has to be Title Cased. Expected "Wechat Devtool"
ready  - validate package.json file
ready  - validate extension icons
ready  - validate extension metadata
ready  - run ESLint
ready  - run Prettier 3.6.2
```

## 🛠️ Solution

Add an `extraFixedCaseWords` configuration option to the `prefer-title-case` rule that allows developers to specify custom fixed-case words for proprietary names.

**Usage:**
```json
{
  "rules": {
    "@raycast/prefer-title-case": ["warn", {
      "extraFixedCaseWords": ["WeChat"]
    }]
  }
}
```

With this configuration, `WeChat` is recognized as valid, eliminating the warning.

This enhancement makes the ESLint plugin more flexible for real-world extension development while maintaining the benefits of consistent title case formatting.